### PR TITLE
fix(globalmercator) fix error when node.js is not used

### DIFF
--- a/globalmercator.js
+++ b/globalmercator.js
@@ -105,7 +105,7 @@
         define(function () {
             return mercator;
         });
-    } else if (module !== undefined) {
+    } else if (typeof module !== 'undefined') {
         module.exports = mercator;
     } else {
         window.mercator = mercator;


### PR DESCRIPTION
The check for module !=== undefined results in a reference error,
check the typeof for the module to prevent this.
